### PR TITLE
Fix compilation error on dunfell

### DIFF
--- a/LISA/Downloader.h
+++ b/LISA/Downloader.h
@@ -31,6 +31,7 @@
 
 #include <memory>
 #include <chrono>
+#include <functional>
 #include <stdexcept>
 
 namespace WPEFramework {


### PR DESCRIPTION
Fixes the following error:
 LISA/Downloader.h:59:35: error: 'function' in namespace 'std' does not name a template type
 |    59 |     using ProgressListener = std::function<void(int)>;
 |       |                                   ^~~~~~~~

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>