### PR TITLE
ONEM-22435 Fixes on GetStorageDetails()

### DIFF
--- a/LISA/Executor.cpp
+++ b/LISA/Executor.cpp
@@ -168,8 +168,7 @@ bool Executor::getStorageParamsValid(const std::string& type,
 uint32_t Executor::GetStorageDetails(const std::string& type,
                            const std::string& id,
                            const std::string& version,
-                           Filesystem::StorageDetails& details,
-                           std::shared_ptr<LISA::DataStorage> storage)
+                           Filesystem::StorageDetails& details)
 {
     namespace fs = Filesystem;
     if(!getStorageParamsValid(type, id, version)) {
@@ -184,20 +183,20 @@ uint32_t Executor::GetStorageDetails(const std::string& type,
         details.persistentUsedKB = std::to_string(fs::getDirectorySpace(fs::getAppsStorageDir()));
     } else {
         INFO("Calculating usage for: type = ", type, " id = ", id, " version = ", version);
-        std::vector<std::string> appsPaths = storage->GetAppsPaths(type, id, version);
+        std::vector<std::string> appsPaths = dataBase->GetAppsPaths(type, id, version);
         long appUsedKB{};
         // In Stage 1 there will be only one entry here
         for(const auto& i: appsPaths)
         {
             appUsedKB += fs::getDirectorySpace(i);
-            details.appPath = i;
+            details.appPath = fs::getAppsDir() + i;
         }
-        std::vector<std::string> dataPaths = storage->GetDataPaths(type, id);
+        std::vector<std::string> dataPaths = dataBase->GetDataPaths(type, id);
         long persistentUsedKB{};
         for(const auto& i: dataPaths)
         {
             persistentUsedKB += fs::getDirectorySpace(i);
-            details.persistentPath = i;
+            details.persistentPath = fs::getAppsStorageDir() + i;
         }
         details.appUsedKB = std::to_string(appUsedKB);
         details.persistentUsedKB = std::to_string(persistentUsedKB);

--- a/LISA/Executor.h
+++ b/LISA/Executor.h
@@ -71,8 +71,7 @@ public:
     uint32_t GetStorageDetails(const std::string& type,
             const std::string& id,
             const std::string& version,
-            Filesystem::StorageDetails& details,
-            std::shared_ptr<LISA::DataStorage> storage);
+            Filesystem::StorageDetails& details);
 
 private:
 

--- a/LISA/Filesystem.cpp
+++ b/LISA/Filesystem.cpp
@@ -187,7 +187,7 @@ long getDirectorySpace(const std::string& path)
         if(directoryExists(path)) {
             for(bf::recursive_directory_iterator it(path); it != bf::recursive_directory_iterator(); ++it)
             {
-                if(!bf::is_directory(*it) && !bf::is_symlink(*it)) {
+                if(bf::exists(*it) && !bf::is_directory(*it) && !bf::is_symlink(*it)) {
                     space += bf::file_size(*it);
                 }
             }

--- a/LISA/LISAImplementation.cpp
+++ b/LISA/LISAImplementation.cpp
@@ -620,7 +620,7 @@ public:
             details.persistentUsedKB = appsStorageKBCache;
         } else {
             INFO("Calculating storage usage");
-            ret = executor.GetStorageDetails(type, id, version, details, ds);
+            ret = executor.GetStorageDetails(type, id, version, details);
         }
         result = Core::Service<StoragePayloadImpl>::Create<ILISA::IStoragePayload>(details);
         return ret;
@@ -636,7 +636,6 @@ private:
     using LockGuard = std::lock_guard<std::mutex>;
     std::list<Exchange::ILISA::INotification*> _notificationCallbacks{};
     std::mutex notificationMutex{};
-    std::shared_ptr<LISA::DataStorage> ds;
     std::string appsKBCache{};
     std::string appsStorageKBCache{};
 };


### PR DESCRIPTION
* return full path insteadof relative path
  (helps starting a container in the rootfs)
* storage pointer is null (crash), use database instead which is
  available. Also cleanup unused storage parameter and ds variable
  from LISAImplementation.
* check file existence while calculating used space
  (helps with symlinks to non-existing files: like links
  that only resolve inside a mounted container)