### PR TITLE
ONEM-22435 Fix pkg_search_module() for sqlite3 in CMakeLists.txt

### DIFF
--- a/LISA/CMakeLists.txt
+++ b/LISA/CMakeLists.txt
@@ -24,6 +24,7 @@ find_package(CompileSettingsDebug CONFIG REQUIRED)
 find_package(CURL REQUIRED)
 find_package(LibArchive REQUIRED)
 find_package(Boost COMPONENTS system filesystem REQUIRED)
+find_package(PkgConfig)
 pkg_search_module(SQLITE REQUIRED sqlite3)
 
 add_library(${MODULE_NAME} SHARED


### PR DESCRIPTION
* on RPI got configure error on pkg_search_module(SQLITE REQUIRED sqlite3)
* adding find_package(PkgConfig) fixes the problem
* rdkservices does it in same way: https://github.com/rdkcentral/rdkservices/blob/sprint/2105/cmake/FindSqlite.cmake