### PR TITLE
ONEM-24090 LISA: fix permissions and (group) ownership of files and dirs

### DIFF
--- a/LISA/CMakeLists.txt
+++ b/LISA/CMakeLists.txt
@@ -43,6 +43,14 @@ set_target_properties(${MODULE_NAME} PROPERTIES
         CXX_STANDARD 11
         CXX_STANDARD_REQUIRED YES)
 
+if (PLUGIN_LISA_APPS_GID)
+  add_definitions(-DLISA_APPS_GID=${PLUGIN_LISA_APPS_GID})
+endif (PLUGIN_LISA_APPS_GID)
+
+if (PLUGIN_LISA_DATA_GID)
+  add_definitions(-DLISA_DATA_GID=${PLUGIN_LISA_DATA_GID})
+endif (PLUGIN_LISA_DATA_GID)
+
 add_subdirectory(AuthModule)
 
 target_link_libraries(${MODULE_NAME}

--- a/LISA/Executor.cpp
+++ b/LISA/Executor.cpp
@@ -606,6 +606,14 @@ void Executor::doMaintanace()
             }
 
         }
+
+#if LISA_APPS_GID
+        Filesystem::setPermissionsRecursively(config.getAppsPath(), LISA_APPS_GID, false);
+#endif
+#if LISA_DATA_GID
+        Filesystem::setPermissionsRecursively(config.getAppsStoragePath(), LISA_DATA_GID, true);
+#endif
+
     }
     catch(std::exception& exc) {
         ERROR("ERROR: ", exc.what());

--- a/LISA/Filesystem.h
+++ b/LISA/Filesystem.h
@@ -65,6 +65,8 @@ bool createDirectory(const std::string& path);
 void removeDirectory(const std::string& path);
 void removeAllDirectoriesExcept(const std::string& path, const std::string& except);
 std::vector<std::string> getSubdirectories(const std::string& path);
+void setPermission(const std::string& path, int uid, int gid, bool isdir, bool writeable);
+void setPermissionsRecursively(const std::string& path, int gid, bool writeable);
 bool isEmpty(const std::string& path);
 
 /**


### PR DESCRIPTION
* this change supports setting group ownership and specific group permissions
* by default nothing happens because it is controlled via build options
* -DPLUGIN_LISA_APPS_GID=XXX to set gid for files and dirs inside apps dir
* -DPLUGIN_LISA_DATA_GID=XXX to set gid for files and dirs inside data dir