### PR TITLE
ONEM-24191 LISA: remove app storage dir when app removed

### DIFF
--- a/LISA/Executor.h
+++ b/LISA/Executor.h
@@ -143,7 +143,7 @@ private:
                      std::string version,
                      std::string uninstallType);
 
-    void doMaintanace();
+    void doMaintenance();
 
     bool getStorageParamsValid(const std::string& type,
             const std::string& id,


### PR DESCRIPTION
* LISA does not remove storage dir of app when it is removed
* Also during maintenance, the algo to detect stale app storage dirs
  is not working properly.