### PR TITLE
ONEM-25082 fix free space and DAC space calculation

### DIFF
--- a/LISA/Downloader.cpp
+++ b/LISA/Downloader.cpp
@@ -70,16 +70,19 @@ Downloader::Downloader(const std::string& uri,
     INFO("Downloader created, uri: ", uri);
 }
 
-long Downloader::getContentLength()
+// returns 0 if error or content length unknown
+unsigned long long Downloader::getContentLength()
 {
     curl_easy_setopt(curl.get(), CURLOPT_NOBODY, 1);
 
     performAction();
 
     curl_off_t curlContentLength{};
-    curl_easy_getinfo(curl.get(), CURLINFO_CONTENT_LENGTH_DOWNLOAD_T, &curlContentLength);
-
-    return static_cast<long>(curlContentLength);
+    auto res = curl_easy_getinfo(curl.get(), CURLINFO_CONTENT_LENGTH_DOWNLOAD_T, &curlContentLength);
+    if (res == CURLE_OK && curlContentLength != -1)
+      return static_cast<unsigned long long>(curlContentLength);
+    else
+      return 0;
 }
 
 void Downloader::get(const std::string& destination)

--- a/LISA/Downloader.h
+++ b/LISA/Downloader.h
@@ -70,7 +70,8 @@ public:
     Downloader(const Downloader& other) = delete;
     Downloader& operator=(const Downloader& other) = delete;
 
-    long getContentLength();
+    // returns 0 if error or content length  unknown
+    unsigned long long getContentLength();
     void get(const std::string& destination);
 
 private:

--- a/LISA/Executor.cpp
+++ b/LISA/Executor.cpp
@@ -264,7 +264,7 @@ uint32_t Executor::GetStorageDetails(const std::string& type,
         } else {
             INFO("Calculating usage for: type = ", type, " id = ", id, " version = ", version);
             std::vector<std::string> appsPaths = dataBase->GetAppsPaths(type, id, version);
-            long appUsedKB{};
+            unsigned long long appUsedKB{};
             // In Stage 1 there will be only one entry here
             for(const auto& i: appsPaths)
             {
@@ -272,7 +272,7 @@ uint32_t Executor::GetStorageDetails(const std::string& type,
                 appUsedKB += fs::getDirectorySpace(details.appPath);
             }
             std::vector<std::string> dataPaths = dataBase->GetDataPaths(type, id);
-            long persistentUsedKB{};
+            unsigned long long persistentUsedKB{};
             for(const auto& i: dataPaths)
             {
                 details.persistentPath = config.getAppsStoragePath() + i;
@@ -481,13 +481,17 @@ void Executor::doInstall(std::string type,
     Downloader downloader{url, *this};
 
     auto downloadSize = downloader.getContentLength();
+    if (downloadSize == 0) {
+        std::string message = std::string{} + "app download size unknown or could not be determined";
+        throw std::runtime_error(message);
+    }
     auto tmpFreeSpace = Filesystem::getFreeSpace(tmpDirPath);
 
-    INFO("download size: ", downloadSize, " free tmp space: ", tmpFreeSpace);
+    INFO("download size: ", downloadSize / 1024, " Kb, free tmp space: ", tmpFreeSpace / 1024, " Kb");
 
     if (downloadSize > tmpFreeSpace) {
         std::string message = std::string{} + "not enough space on " + tmpPath + " (available: "
-                + std::to_string(tmpFreeSpace) +", required: " + std::to_string(downloadSize) + ")";
+                + std::to_string(tmpFreeSpace / 1024) +" Kb, required: " + std::to_string(downloadSize / 1024) + " Kb)";
         throw std::runtime_error(message);
     }
 

--- a/LISA/Filesystem.cpp
+++ b/LISA/Filesystem.cpp
@@ -225,9 +225,9 @@ bool isEmpty(const std::string& path)
     return result;
 }
 
-long getFreeSpace(const std::string& path)
+unsigned long long getFreeSpace(const std::string& path)
 {
-    long freeSpace{};
+    unsigned long long freeSpace{};
 
     try {
         auto boostSpace = boost::filesystem::space(path);
@@ -241,9 +241,9 @@ long getFreeSpace(const std::string& path)
     return freeSpace;
 }
 
-long getDirectorySpace(const std::string& path)
+unsigned long long getDirectorySpace(const std::string& path)
 {
-    long space{};
+    uintmax_t space{};
     namespace bf = boost::filesystem;
     try {
         if(directoryExists(path)) {
@@ -259,7 +259,7 @@ long getDirectorySpace(const std::string& path)
         std::string message = std::string{} + "error " + error.what() + " reading directory space on " + path;
         throw FilesystemError(message);
     }
-    return space;
+    return (unsigned long long)space;
 }
 
 } // namespace Filesystem

--- a/LISA/Filesystem.h
+++ b/LISA/Filesystem.h
@@ -90,8 +90,8 @@ private:
     std::string dirToRemove{};
 };
 
-long getFreeSpace(const std::string& path);
-long getDirectorySpace(const std::string& path);
+unsigned long long getFreeSpace(const std::string& path);
+unsigned long long getDirectorySpace(const std::string& path);
 
 } // namespace Filesystem
 } // namespace LISA


### PR DESCRIPTION
Space and size calculations overflow when free space > +/- 2GB
because of signed long overflow. Switch to using unsigned long long (64-bit).

Also check for error when fetching download size of DAC
app.