### PR TITLE
ONEM-28398 fix issues after uninstalling app with uninstallType=upgrade

### DIFF
--- a/LISA/DataStorage.h
+++ b/LISA/DataStorage.h
@@ -44,6 +44,17 @@ class DataStorage {
             std::string appName;
             std::string category;
             std::string url;
+
+            AppDetails() {}
+            AppDetails(const char *type_, const char *id_, const char *version_, const char *appName_,
+                       const char *category_, const char *url_) {
+                type = type_ ? type_ : "";
+                id = id_ ? id_ : "";
+                version = version_ ? version_ : "";
+                appName = appName_ ? appName_ : "";
+                category = category_ ? category_ : "";
+                url = url_ ? url_ : "";
+            }
         };
 
         struct AppMetadata
@@ -64,6 +75,11 @@ class DataStorage {
                                                           const std::string& version = {},
                                                           const std::string& appName = {},
                                                           const std::string& category = {}) = 0;
+        virtual std::vector<AppDetails> GetAppDetailsListOuterJoin(const std::string& type = {},
+                                                      const std::string& id = {},
+                                                      const std::string& version = {},
+                                                      const std::string& appName = {},
+                                                      const std::string& category = {}) = 0;
 
         virtual void AddInstalledApp(const std::string& type,
                                      const std::string& id,

--- a/LISA/Executor.h
+++ b/LISA/Executor.h
@@ -222,10 +222,6 @@ private:
 
     void doMaintenance();
 
-    bool getStorageParamsValid(const std::string& type,
-            const std::string& id,
-            const std::string& version) const;
-
     void setProgress(int progress) override;
     bool isCancelled() override;
     void setProgress(int percentValue, OperationStage stage);

--- a/LISA/LISAImplementation.cpp
+++ b/LISA/LISAImplementation.cpp
@@ -918,7 +918,13 @@ public:
             std::map<std::pair<std::string, std::string>, std::list<AppVersionImpl*>> appsDet;
             for(const auto& app: appsDetailsList)
             {
-                appsDet[{app.type, app.id}].push_back(Core::Service<AppVersionImpl>::Create<AppVersionImpl>(app.version, app.appName, app.category, app.url));
+                if (app.version.empty()) {
+                    appsDet[{app.type, app.id}].clear();
+                } else {
+                    appsDet[{app.type, app.id}].push_back(
+                            Core::Service<AppVersionImpl>::Create<AppVersionImpl>(app.version, app.appName,
+                                                                                  app.category, app.url));
+                }
             }
             std::list<AppImpl*> apps;
             for(const auto& app: appsDet)

--- a/LISA/SqlDataStorage.h
+++ b/LISA/SqlDataStorage.h
@@ -49,6 +49,8 @@ class SqlDataStorage: public DataStorage
         std::vector<DataStorage::AppDetails> GetAppDetailsList(const std::string& type, const std::string& id, const std::string& version,
                                                   const std::string& appName, const std::string& category) override;
 
+        std::vector<DataStorage::AppDetails> GetAppDetailsListOuterJoin(const std::string& type, const std::string& id, const std::string& version,
+                                                                        const std::string& appName, const std::string& category) override;
         void AddInstalledApp(const std::string& type,
                              const std::string& id,
                              const std::string& version,

--- a/LISA/tests/LISATests.cpp
+++ b/LISA/tests/LISATests.cpp
@@ -603,53 +603,71 @@ CATCH_TEST_CASE("LISA : uninstall test (upgrade), followed by full uninstall", "
     CATCH_REQUIRE(waitForEvent(30));
     CATCH_CHECK(last_event_received_.status == Executor::OperationStatus::SUCCESS);
 
-    string uninstall_handle;
-    result = lisa.Uninstall("application/vnd.rdk-app.dac.native", "com.rdk.waylandegltest", "1.0.0", "upgrade" , uninstall_handle);
-    CATCH_REQUIRE(result == 0);
-    CATCH_REQUIRE_FALSE(uninstall_handle.empty());
-    CATCH_REQUIRE(waitForEvent(30));
-    CATCH_CHECK(last_event_received_.operation == Executor::OperationType::UNINSTALLING);
-    CATCH_CHECK(last_event_received_.status == Executor::OperationStatus::SUCCESS);
+    CATCH_SECTION( "normal case: uninstall  (upgrade) followed by full uninstall" ) {
+        string uninstall_handle;
+        result = lisa.Uninstall("application/vnd.rdk-app.dac.native", "com.rdk.waylandegltest", "1.0.0", "upgrade",
+                                uninstall_handle);
+        CATCH_REQUIRE(result == 0);
+        CATCH_REQUIRE_FALSE(uninstall_handle.empty());
+        CATCH_REQUIRE(waitForEvent(30));
+        CATCH_CHECK(last_event_received_.operation == Executor::OperationType::UNINSTALLING);
+        CATCH_CHECK(last_event_received_.status == Executor::OperationStatus::SUCCESS);
 
-    CATCH_CHECK(countAppsInDB() == 1);
-    CATCH_CHECK(countInstalledAppsInDB() == 0);
-    CATCH_CHECK(!findPathInAppsPath("0/com.rdk.waylandegltest/1.0.0/rootfs/usr/bin/wayland-egl-test"));
-    CATCH_CHECK(findPathInStoragePath("0/com.rdk.waylandegltest"));
+        CATCH_CHECK(countAppsInDB() == 1);
+        CATCH_CHECK(countInstalledAppsInDB() == 0);
+        CATCH_CHECK(!findPathInAppsPath("0/com.rdk.waylandegltest/1.0.0/rootfs/usr/bin/wayland-egl-test"));
+        CATCH_CHECK(findPathInStoragePath("0/com.rdk.waylandegltest"));
 
-    Filesystem::StorageDetails details;
-    result = lisa.GetStorageDetails("application/vnd.rdk-app.dac.native", "com.rdk.waylandegltest", "", details);
-    CATCH_CHECK(result == 0);
-    CATCH_CHECK(details.appPath.empty());
-    CATCH_CHECK(details.persistentPath == (lisa_playground + data_subpath + "/0/com.rdk.waylandegltest/"));
+        Filesystem::StorageDetails details;
+        result = lisa.GetStorageDetails("application/vnd.rdk-app.dac.native", "com.rdk.waylandegltest", "", details);
+        CATCH_CHECK(result == 0);
+        CATCH_CHECK(details.appPath.empty());
+        CATCH_CHECK(details.persistentPath == (lisa_playground + data_subpath + "/0/com.rdk.waylandegltest/"));
 
-    std::vector<DataStorage::AppDetails> appDetails;
-    result = lisa.GetAppDetailsList("application/vnd.rdk-app.dac.native", "com.rdk.waylandegltest", "", "", "", appDetails);
-    CATCH_CHECK(result == 0);
-    CATCH_CHECK(appDetails.size() == 1);
+        std::vector<DataStorage::AppDetails> appDetails;
+        result = lisa.GetAppDetailsList("application/vnd.rdk-app.dac.native", "com.rdk.waylandegltest", "", "", "",
+                                        appDetails);
+        CATCH_CHECK(result == 0);
+        CATCH_CHECK(appDetails.size() == 1);
 
-    uninstall_handle = "";
-    result = lisa.Uninstall("application/vnd.rdk-app.dac.native", "com.rdk.waylandegltest", "", "full" , uninstall_handle);
-    CATCH_REQUIRE(result == 0);
-    CATCH_REQUIRE_FALSE(uninstall_handle.empty());
-    CATCH_REQUIRE(waitForEvent(30));
-    CATCH_CHECK(last_event_received_.operation == Executor::OperationType::UNINSTALLING);
-    CATCH_CHECK(last_event_received_.status == Executor::OperationStatus::SUCCESS);
+        uninstall_handle = "";
+        result = lisa.Uninstall("application/vnd.rdk-app.dac.native", "com.rdk.waylandegltest", "", "full",
+                                uninstall_handle);
+        CATCH_REQUIRE(result == 0);
+        CATCH_REQUIRE_FALSE(uninstall_handle.empty());
+        CATCH_REQUIRE(waitForEvent(30));
+        CATCH_CHECK(last_event_received_.operation == Executor::OperationType::UNINSTALLING);
+        CATCH_CHECK(last_event_received_.status == Executor::OperationStatus::SUCCESS);
 
-    CATCH_CHECK(countAppsInDB() == 0);
-    CATCH_CHECK(countInstalledAppsInDB() == 0);
-    CATCH_CHECK(!findPathInAppsPath("0/com.rdk.waylandegltest/1.0.0/rootfs/usr/bin/wayland-egl-test"));
-    CATCH_CHECK(!findPathInStoragePath("0/com.rdk.waylandegltest"));
+        CATCH_CHECK(countAppsInDB() == 0);
+        CATCH_CHECK(countInstalledAppsInDB() == 0);
+        CATCH_CHECK(!findPathInAppsPath("0/com.rdk.waylandegltest/1.0.0/rootfs/usr/bin/wayland-egl-test"));
+        CATCH_CHECK(!findPathInStoragePath("0/com.rdk.waylandegltest"));
 
-    Filesystem::StorageDetails details2;
-    result = lisa.GetStorageDetails("application/vnd.rdk-app.dac.native", "com.rdk.waylandegltest", "", details2);
-    CATCH_CHECK(result == 0);
-    CATCH_CHECK(details2.appPath.empty());
-    CATCH_CHECK(details2.persistentPath.empty());
+        Filesystem::StorageDetails details2;
+        result = lisa.GetStorageDetails("application/vnd.rdk-app.dac.native", "com.rdk.waylandegltest", "", details2);
+        CATCH_CHECK(result == 0);
+        CATCH_CHECK(details2.appPath.empty());
+        CATCH_CHECK(details2.persistentPath.empty());
 
-    std::vector<DataStorage::AppDetails> appDetails2;
-    result = lisa.GetAppDetailsList("application/vnd.rdk-app.dac.native", "com.rdk.waylandegltest", "", "", "", appDetails2);
-    CATCH_CHECK(result == 0);
-    CATCH_CHECK(appDetails2.size() == 0);
+        std::vector<DataStorage::AppDetails> appDetails2;
+        result = lisa.GetAppDetailsList("application/vnd.rdk-app.dac.native", "com.rdk.waylandegltest", "", "", "",
+                                        appDetails2);
+        CATCH_CHECK(result == 0);
+        CATCH_CHECK(appDetails2.size() == 0);
+    }
+
+    CATCH_SECTION( "special case: trying full uninstall without version specified, when app still installed" ) {
+        string uninstall_handle = "";
+        result = lisa.Uninstall("application/vnd.rdk-app.dac.native", "com.rdk.waylandegltest", "", "full",
+                                uninstall_handle);
+        CATCH_REQUIRE(result == Executor::ReturnCodes::ERROR_WRONG_PARAMS);
+
+        CATCH_CHECK(countAppsInDB() == 1);
+        CATCH_CHECK(countInstalledAppsInDB() == 1);
+        CATCH_CHECK(findPathInAppsPath("0/com.rdk.waylandegltest/1.0.0/rootfs/usr/bin/wayland-egl-test"));
+        CATCH_CHECK(findPathInStoragePath("0/com.rdk.waylandegltest"));
+    }
 }
 
 void outputFile(string path, string contents) {


### PR DESCRIPTION
After uninstalling an app with uninstallType=upgrade:

* getList() should still return type+id but without any installed apps (=versions)
* getStorageDetails() should return a storagePath and allow calling with empty version
* fix related problem in doMaintenance()
* allow uninstall (type=full) to be called with empty version so that the remaing storage dir and app record can get removed
* make sure metadata is automatically removed when removing an app