### PR TITLE
ONEM-32803 LISA: should return 1001 on getStorageDetails() when app n…

### DIFF
--- a/LISA/Executor.cpp
+++ b/LISA/Executor.cpp
@@ -385,6 +385,10 @@ uint32_t Executor::GetStorageDetails(const std::string& type,
             INFO("Calculating usage for: type = ", type, " id = ", id, " version = ", version);
             if (!version.empty()) {
                 std::vector<std::string> appsPaths = dataBase->GetAppsPaths(type, id, version);
+                if (appsPaths.empty()) {
+                    // return error when app not found
+                    return ERROR_WRONG_PARAMS;
+                }
                 unsigned long long appUsedKB{};
                 // In Stage 1 there will be only one entry here
                 for (const auto &i: appsPaths) {

--- a/LISA/tests/LISATests.cpp
+++ b/LISA/tests/LISATests.cpp
@@ -270,6 +270,10 @@ CATCH_TEST_CASE("LISA : install app", "[all][test1][quick]") {
     CATCH_CHECK(countInstalledAppsInDB() == 1);
     CATCH_CHECK(findPathInAppsPath("0/com.rdk.waylandegltest/1.0.0/rootfs/usr/bin/wayland-egl-test"));
     CATCH_CHECK(findPathInStoragePath("0/com.rdk.waylandegltest"));
+
+    // check error code in case of app not found
+    result = lisa.GetStorageDetails(DACAPP_MIME, "invalid", DACAPP_VERSION, details);
+    CATCH_REQUIRE(result == Executor::ReturnCodes::ERROR_WRONG_PARAMS);
 }
 
 CATCH_TEST_CASE("LISA : install 2 apps", "[all][test2][quick]") {


### PR DESCRIPTION
…ot found

When type, id and version are passed when requesting getStorageDetails() this function returns data specific to that app version. When no such app, version and type combination exists LISA returns an empty response like:

wscat -c ws://$BOX/jsonrpc -s notification -x '{"jsonrpc":"2.0","id":1,"method":"LISA.1.getStorageDetails", "params": { "id": "com.libertyglobal.app.chocolate-doom", "type":"application/vnd.rdk-app.dac.native", "version": "1.0" } }' | jq '.'

{
  "jsonrpc": "2.0",
  "id": 1,
  "result": {
    "apps": {
      "path": "",
      "quotaKB": "",
      "usedKB": "0"
    },
    "persistent": {
      "path": "",
      "quotaKB": "",
      "usedKB": "0"
    }
  }
}

Instead it should return 1001/ERROR_WRONG_PARAMS in that case. This change is requested here: https://github.com/stagingrdkm/LISA/issues/46